### PR TITLE
Feature - add delete meal route

### DIFF
--- a/api/controllers/meal.controllers.js
+++ b/api/controllers/meal.controllers.js
@@ -35,7 +35,7 @@ const MealController = {
   deleteAMealOption(req, res) {
     const { id } = req.params;
     const mealOptionToBeDeleted = MealService.deleteAMealOption(id);
-    res.status(201).json({
+    res.status(204).json({
       status: 'Meal deleted successfully',
       data: allMeals,
     });

--- a/api/controllers/meal.controllers.js
+++ b/api/controllers/meal.controllers.js
@@ -20,7 +20,7 @@ const MealController = {
     const newMeal = req.body;
     const createdMeal = MealService.addMeal(newMeal);
     return res.status(201).json({
-      status: 'Success',
+      status: 'Meal option added successfully',
       data: createdMeal,
     });
   },
@@ -28,8 +28,16 @@ const MealController = {
     const { id } = req.params;
     const foundMeal = MealService.getAMeal(id);
     res.status(200).json({
-      status: 'Success',
+      status: 'Meal retrieved successfully',
       data: foundMeal,
+    });
+  },
+  deleteAMealOption(req, res) {
+    const { id } = req.params;
+    const mealOptionToBeDeleted = MealService.deleteAMealOption(id);
+    res.status(201).json({
+      status: 'Meal deleted successfully',
+      data: allMeals,
     });
   },
 };

--- a/api/routes/meal.routes.js
+++ b/api/routes/meal.routes.js
@@ -6,5 +6,7 @@ const router = Router();
 router.get('/', MealController.fetchAllMeals);
 router.post('/', MealController.addAMealOption);
 router.get('/:id', MealController.getAMealOption);
+router.delete('/:id', MealController.deleteAMealOption);
+
 
 export default router;

--- a/api/services/meal.services.js
+++ b/api/services/meal.services.js
@@ -22,8 +22,14 @@ const MealService = {
     return meal;
   },
   getAMeal(id) {
-    const meal = dummyDBData.meals.find(meal => meal.id === id);
+    const meal = dummyDBData.meals.find((meal) => meal.id === id);
     return meal || {};
+  },
+  deleteAMealOption(id) {
+    const meal = dummyDBData.meals.find((meal) => meal.id === id);
+    const index = dummyDBData.meals.indexOf(meal);
+    dummyDBData.meals.splice(index, 1);
+    return {};
   },
 };
 


### PR DESCRIPTION
#### What does this PR do?
Adds meal delete route
#### What particular Task was completed?
As part of CRUD for the API endpoints, delete meal route was added.
#### How can this be tested?
After running `npm start` then use postman to test the deleting a particular meal.
Running a *delete* command, in postman, on `localhost:9000/api/v1/(mealId)` 