### PR TITLE
Chore/Installed babel-register to inform mocha of ES5+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4395,9 +4395,9 @@
       "dev": true
     },
     "pirates": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.0.tgz",
-      "integrity": "sha512-8t5BsXy1LUIjn3WWOlOuFDuKswhQb/tkak641lvBgmPOBUQHXveORtlMCp6OdPV1dtuTaEahKA8VNz6uLfKBtA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+      "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
       "dev": true,
       "requires": {
         "node-modules-regexp": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"@babel/core": "^7.2.2",
 		"@babel/node": "^7.2.2",
 		"@babel/preset-env": "^7.3.1",
+		"@babel/register": "^7.0.0",
 		"chai": "^4.2.0",
 		"eslint": "^5.13.0",
 		"eslint-config-airbnb": "^17.1.0",


### PR DESCRIPTION
Installed babel-register to let mocha know I am using 